### PR TITLE
Add request caching to http clients

### DIFF
--- a/dapla/services/clients.py
+++ b/dapla/services/clients.py
@@ -1,6 +1,8 @@
 import requests
+import requests_cache
 import json
 
+requests_cache.install_cache('client_cache', backend='memory', expire_after=2)
 
 class AbstractClient:
     def __init__(
@@ -145,8 +147,7 @@ class DatasetDocClient(AbstractClient):
         request_url = self._base_url + '/doc/candidates/' + concept_type
         response = requests.get(request_url,
                                 headers={
-                                    'Authorization': 'Bearer %s' % self._user_token_provider(),
-                                    'Cache-Control': '10'
+                                    'Authorization': 'Bearer %s' % self._user_token_provider()
                                 }, allow_redirects=False)
         handle_error_codes(response)
         return response.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ jupyterhub
 oauthenticator
 jwt
 requests
+requests-cache
 responses
 ipykernel>=4.2.2
 notebook>=4.2

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -3,6 +3,7 @@ import responses
 import unittest
 import time
 
+
 class ClientsTest(unittest.TestCase):
     @responses.activate
     def test_data_access_client(self):
@@ -27,6 +28,15 @@ class ClientsTest(unittest.TestCase):
             client = DataAccessClient(lambda: 'mock-user-token', 'http://mock.no/')
             client.read_location('/user/test')
 
+    @responses.activate
+    def test_error_handling(self):
+        responses.add(responses.GET, 'http://mock.no/doc/candidates/UnitType',
+                      json={'test': 'test-a'}, status=200)
+        client = DatasetDocClient(lambda: 'mock-user-token', 'http://mock.no/')
+        for i in range(10):
+            client.get_doc_template_candidates('unitType')
+        assert len(responses.calls) == 1
+
     @unittest.skip  # for testing against local running service
     def test_dataset_doc_client(self):
         client = DatasetDocClient(lambda: 'mock-user-token', 'http://localhost:10190/')
@@ -35,7 +45,3 @@ class ClientsTest(unittest.TestCase):
             candidates = client.get_doc_template_candidates('unitType')
             print(candidates)
             time.sleep(0.2)
-
-
-
-

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,7 +1,7 @@
-from dapla.services.clients import DataAccessClient, DataAccessError
+from dapla.services.clients import DataAccessClient, DataAccessError, DatasetDocClient
 import responses
 import unittest
-
+import time
 
 class ClientsTest(unittest.TestCase):
     @responses.activate
@@ -26,6 +26,16 @@ class ClientsTest(unittest.TestCase):
         with self.assertRaisesRegex(DataAccessError, 'Fant ikke datasett'):
             client = DataAccessClient(lambda: 'mock-user-token', 'http://mock.no/')
             client.read_location('/user/test')
+
+    @unittest.skip  # for testing against local running service
+    def test_dataset_doc_client(self):
+        client = DatasetDocClient(lambda: 'mock-user-token', 'http://localhost:10190/')
+
+        for i in range(20):
+            candidates = client.get_doc_template_candidates('unitType')
+            print(candidates)
+            time.sleep(0.2)
+
 
 
 


### PR DESCRIPTION
Using [requests-cache](https://pypi.org/project/requests-cache/) to cache all requests with 2 sec to avoid call for every field when doing dataset documentation

Tested [ CacheControl](https://cachecontrol.readthedocs.io/en/latest/) but did not work for me