### PR TITLE
Feature/use smart matches

### DIFF
--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -79,6 +79,10 @@ class DaplaDocumentationMagics(Magics):
         from IPython.display import clear_output
         clear_output()
 
+    @staticmethod
+    def get_dataset_path(dataset_name):
+        return find_dataset_path(dataset_name)
+
     @line_magic
     def find_path(self, dataset_name):
         """For testing, can be removed
@@ -185,13 +189,13 @@ class DaplaDocumentationMagics(Magics):
                         ds.doc = json.load(f)
                 else:
                     # Generate doc from template and prepare file
-                    dataset_path = find_dataset_path(args)
+                    dataset_path = self.get_dataset_path(args)
                     ds.doc = self._doc_template_provider(ds.schema.json(), False, dataset_path)
                     with open(fname, 'w', encoding="utf-8") as f:
                         json.dump(ds.doc, f)
             else:
                 # Generate doc from template
-                dataset_path = find_dataset_path(args)
+                dataset_path = self.get_dataset_path(args)
                 ds.doc = self._doc_template_provider(ds.schema.json(), False, dataset_path)
 
         except AuthError as err:

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -52,10 +52,15 @@ def remove_not_selected(doc_json):
     def filter_not_selected_variables(variable):
         if variable['dataStructureComponentType']['selected-enum'] == '':
             return False
+        if variable['dataStructureComponentType'].__contains__('smart-enum'):
+            del variable['dataStructureComponentType']['smart-enum']
         types = ('population', 'representedVariable', 'sentinelValueDomain')
         for t in types:
             if variable[t]['selected-id'] == 'please-select':
                 return False
+            if variable[t].__contains__('smart-match-id'):
+                del variable[t]['smart-match-id']
+
         return variable['description'] is not None and variable['description'] != ''
 
     def map_variable(variable):

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -406,8 +406,8 @@ class DaplaDocumentationMagics(Magics):
             if cand['id'] == selected_id:
                 return selected_id
 
-        # TODO: fix this when loading existing json
-        if selected_id != "" and selected_id != "please-select":  # we have an id but it have been removed from candidates (Concept-lds)
+        if selected_id != "" and selected_id != "please-select":
+            # we have an id but it have been removed from candidates (Concept-lds)
             self._status = '{}" is removed! please make a new selection'.format(selected_id)
 
         # add please select to candidates and make this selected
@@ -426,7 +426,7 @@ class DaplaDocumentationMagics(Magics):
         selected_id = binding_key['selected-id']
         if binding_key.__contains__('smart-match-id') and binding_key['smart-match-id'] != "":
             smart_match_id = binding_key['smart-match-id']
-            selected_id = smart_match_id  # TODO: show this on control
+            selected_id = smart_match_id
             self._is_smart_match = 'sm'
 
         candidates_from_service = self._doc_template_candidates_provider(key)

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -303,7 +303,7 @@ class DaplaDocumentationMagics(Magics):
             self._status = '{}" is removed! please make a new selection'.format(selected_id)
 
         # add please select to candidates and make this selected
-        candidates.append({
+        candidates.insert(0, {
             'id': 'please-select',
             'name': 'please select'
         })

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -171,7 +171,7 @@ class DaplaDocumentationMagics(Magics):
             else:
                 dropdown = [label, inst_dropdown, widgets.HTML(self._status)]
                 self._result_status = \
-                    '<br/><i style="font-size:12px;color:red">' +\
+                    '<br/><i style="font-size:12px;color:red">' + \
                     'Types have been removed from Concept! Please check each instance variable</i>'
                 self._status = None
             return widgets.Box(dropdown, layout=form_item_layout)
@@ -212,7 +212,8 @@ class DaplaDocumentationMagics(Magics):
         )
 
         display_objs = (widgets.HTML('<b style="font-size:14px">Dataset metadata</b>'), dataset_doc,
-                        widgets.HTML('<b style="font-size:14px">Instance variables</b>{}'.format(self._result_status)), accordion)
+                        widgets.HTML('<b style="font-size:14px">Instance variables</b>{}'.format(self._result_status)),
+                        accordion)
 
         def on_button_clicked(b):
             with open(fname, 'w', encoding="utf-8") as f:
@@ -289,8 +290,11 @@ class DaplaDocumentationMagics(Magics):
     def create_candidate_selector(self, binding, key):
         component = widgets.Dropdown()
         binding_key = binding[key]
-        candidates = binding_key['candidates']
+        candidates = []
         selected_id = binding_key['selected-id']
+        if binding_key.__contains__('smart-match-id'):
+            smart_match_id = binding_key['smart-match-id']
+            selected_id = smart_match_id  # TODO: show this on control
 
         candidates_from_service = self._doc_template_candidates_provider(key)
         if len(candidates_from_service) > 0:

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -12,6 +12,7 @@ from ..services.clients import DatasetDocClient
 from ..jupyterextensions.authextension import AuthClient, AuthError
 from ..magics.lineage import find_dataset_path
 
+
 def extract_doc(df):
     if not isinstance(df, DataFrame):
         raise UsageError("The variable '{}' is not a pyspark DataFrame".format(df))
@@ -297,16 +298,17 @@ class DaplaDocumentationMagics(Magics):
         for cand in candidates:
             if cand['id'] == selected_id:
                 return selected_id
-        # return first if selected id is not found
+
+        # add please select to candidates and make this selected
         candidates.append({
             'id': 'please-select',
             'name': 'please select'
         })
-
         first = 'please-select'  # candidates[0]['id']
 
-        #  We need to detect if this happens when loading a previous selection for file...
-        #  self._status = '{}" is removed! selecting:{}'.format(selected_id, first)
+        if selected_id != "":  # we have an id but it have been removed from candidates (Concept-lds)
+            self._status = '{}" is removed! selecting:{}'.format(selected_id, first)
+
         return first
 
     def create_candidate_selector(self, binding, key):

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -254,12 +254,18 @@ class DaplaDocumentationMagics(Magics):
             return s[0].upper() + s[1:]
 
         def create_dropdown_box(dict, title, key):
+            def get_title(name):
+                if self._is_smart_match != '':
+                    return name + ' - ' + self._is_smart_match
+                return name
+
             inst_dropdown = self.create_widget(dict, key)
-            label = widgets.Label(value=title)
             if self._status is None:
-                dropdown = [label, inst_dropdown, widgets.HTML(self._is_smart_match)]
+                label = widgets.Label(value=get_title(title))
+                dropdown = [label, inst_dropdown] 
                 self._is_smart_match = ''
             else:
+                label = widgets.Label(value=title)
                 dropdown = [label, inst_dropdown, widgets.HTML(self._status)]
                 self._result_status = \
                     '<br/><i style="font-size:12px;color:red">' + \

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -153,8 +153,6 @@ class DaplaDocumentationMagics(Magics):
                     key
                 )
 
-        # self.display(widgets.HTML('Create a validation test 2 report <i>{}</i>'.format(dataset_name)))
-        # return 'Create a validation report {}'.format(dataset_name)
 
     @line_magic
     def document(self, line):

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -47,6 +47,30 @@ def map_doc_output(doc_json):
         'instanceVariables': list(map(map_variable, filter(filter_ignored_variables, doc_json['instanceVariables'])))}
 
 
+def remove_not_selected(doc_json):
+    def filter_not_selected_variables(variable):
+        if variable['dataStructureComponentType']['selected-enum'] == '':
+            return False
+        types = ('population', 'representedVariable', 'sentinelValueDomain')
+        for t in types:
+            if variable[t]['selected-id'] == 'please-select':
+                return False
+        return variable['description'] is not None and variable['description'] != ''
+
+    def map_variable(variable):
+        return dict(map(map_variable_field, variable.items()))
+
+    def map_variable_field(variable_field):
+        return variable_field
+
+    return {
+        'name': doc_json['name'],
+        'description': doc_json['description'],
+        'unitType': doc_json['unitType'],
+        'instanceVariables': list(
+            map(map_variable, filter(filter_not_selected_variables, doc_json['instanceVariables'])))}
+
+
 @magics_class
 class DaplaDocumentationMagics(Magics):
     """Magics related to documentation management (loading, saving, editing, ...)."""

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -122,7 +122,7 @@ class DaplaDocumentationMagics(Magics):
                 )
 
         # self.display(widgets.HTML('Create a validation test 2 report <i>{}</i>'.format(dataset_name)))
-        #return 'Create a validation report {}'.format(dataset_name)
+        # return 'Create a validation report {}'.format(dataset_name)
 
     @line_magic
     def document(self, line):
@@ -331,6 +331,8 @@ class DaplaDocumentationMagics(Magics):
                 and binding[key].__contains__('smart-enum') \
                 and binding[key]['smart-enum'] is not None:
             key_selected_enum = binding[key]['smart-enum']
+            binding[key]['selected-enum'] = key_selected_enum
+
             self._is_smart_match = 'sm'
 
         if key_selected_enum == '':

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -227,17 +227,18 @@ class DaplaDocumentationMagics(Magics):
             self.display(widgets.VBox(display_objs))
 
     def create_widget(self, binding, key):
-        if isinstance(binding[key], str):
+        binding_key = binding[key]
+        if isinstance(binding_key, str):
             return self.create_text_input(binding, key)
-        elif isinstance(binding[key], bool):
+        elif isinstance(binding_key, bool):
             return self.create_checkbox_input(binding, key)
-        elif isinstance(binding[key], dict) and binding[key].__contains__('enums'):
+        elif isinstance(binding_key, dict) and binding_key.__contains__('enums'):
             return self.create_enum_selector(binding, key)
-        elif isinstance(binding[key], dict) and binding[key].__contains__('candidates'):
+        elif isinstance(binding_key, dict) and binding_key.__contains__('candidates'):
             return self.create_candidate_selector(binding, key)
         else:
             raise UsageError("Unable to create a widget for '{}' with value '{}'\n{}"
-                             .format(key, binding[key], json.dumps(binding, indent=2)))
+                             .format(key, binding_key, json.dumps(binding, indent=2)))
 
     def create_text_input(self, binding, key):
         if key == 'description':

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -370,10 +370,10 @@ class DaplaDocumentationMagics(Magics):
                 and binding[key]['smart-enum'] is not None:
             key_selected_enum = binding[key]['smart-enum']
             binding[key]['selected-enum'] = key_selected_enum
-
             self._is_smart_match = 'sm'
 
         if key_selected_enum == '':
+            self._is_smart_match = ''  # in case smart-enum is empty
             key_selected_enum = 'please select'
             enums.insert(0, 'please select')
 

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -8,7 +8,6 @@ import os
 import json
 from pyspark.sql import DataFrame
 import ipywidgets as widgets
-from IPython import get_ipython
 from ..services.clients import DatasetDocClient
 from ..jupyterextensions.authextension import AuthClient, AuthError
 from ..magics.lineage import find_dataset_path
@@ -81,6 +80,8 @@ class DaplaDocumentationMagics(Magics):
 
     @line_magic
     def find_path(self, dataset_name):
+        """For testing, can be removed
+        """
         return find_dataset_path(dataset_name)
 
     @line_magic
@@ -297,8 +298,15 @@ class DaplaDocumentationMagics(Magics):
             if cand['id'] == selected_id:
                 return selected_id
         # return first if selected id is not found
-        first = candidates[0]['id']
-        self._status = '{}" is removed! selecting:{}'.format(selected_id, first)
+        candidates.append({
+            'id': 'please-select',
+            'name': 'please select'
+        })
+
+        first = 'please-select'  # candidates[0]['id']
+
+        #  We need to detect if this happens when loading a previous selection for file...
+        #  self._status = '{}" is removed! selecting:{}'.format(selected_id, first)
         return first
 
     def create_candidate_selector(self, binding, key):

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -131,12 +131,19 @@ class DaplaDocumentationMagics(Magics):
         def capitalize_with_camelcase(s):
             return s[0].upper() + s[1:]
 
+        def status(instance):
+            if instance['dataStructureComponentType']['selected-enum'] == '':
+                return 'not selected'
+            if instance['dataStructureComponentType'].__contains__('smart-enum'):
+                return 'smart'
+            return 'ok'
+
         variable_titles = []
         for instance_var in doc['instanceVariables']:
             camelcase = capitalize_with_camelcase(instance_var['name'])
             variable_titles.append(camelcase)
             items = []
-            self.display(widgets.HTML('name: {}'.format(camelcase)))
+            self.display(widgets.HTML('<b>{}</b> <i>{}</i>'.format(camelcase, status(instance_var))))
 
             for key in instance_var.keys():
                 if key == 'name' or key == 'smart-description':

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -17,7 +17,8 @@ def extract_doc(df):
     if not isinstance(df, DataFrame):
         raise UsageError("The variable '{}' is not a pyspark DataFrame".format(df))
     if hasattr(df, 'doc'):
-        return map_doc_output(df.doc)
+        output = map_doc_output(df.doc)
+        return remove_not_selected(output)
     else:
         return None
 

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -57,6 +57,7 @@ class DaplaDocumentationMagics(Magics):
         self._doc_template_candidates_provider = doc_template_candidates_provider
         self._status = None
         self._result_status = ''
+        self._is_smart_match = ''  # TODO: find a better solutions to this
 
     @staticmethod
     def ensure_valid_filename(fname):
@@ -167,7 +168,8 @@ class DaplaDocumentationMagics(Magics):
             inst_dropdown = self.create_widget(dict, key)
             label = widgets.Label(value=title)
             if self._status is None:
-                dropdown = [label, inst_dropdown]
+                dropdown = [label, inst_dropdown, widgets.HTML(self._is_smart_match)]
+                self._is_smart_match = ''
             else:
                 dropdown = [label, inst_dropdown, widgets.HTML(self._status)]
                 self._result_status = \
@@ -295,6 +297,7 @@ class DaplaDocumentationMagics(Magics):
         if binding_key.__contains__('smart-match-id'):
             smart_match_id = binding_key['smart-match-id']
             selected_id = smart_match_id  # TODO: show this on control
+            self._is_smart_match = 'sm'
 
         candidates_from_service = self._doc_template_candidates_provider(key)
         if len(candidates_from_service) > 0:

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -400,7 +400,8 @@ class DaplaDocumentationMagics(Magics):
             if cand['id'] == selected_id:
                 return selected_id
 
-        if selected_id != "":  # we have an id but it have been removed from candidates (Concept-lds)
+        # TODO: fix this when loading existing json
+        if selected_id != "" and selected_id != "please-select":  # we have an id but it have been removed from candidates (Concept-lds)
             self._status = '{}" is removed! please make a new selection'.format(selected_id)
 
         # add please select to candidates and make this selected

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -194,7 +194,7 @@ class DaplaDocumentationMagics(Magics):
             form_items = []
 
             for key in instanceVar.keys():
-                if key == 'name':
+                if key == 'name' or key == 'smart-description':
                     continue
                 form_items.append(
                     create_dropdown_box(instanceVar, capitalize_with_camelcase(key), key)
@@ -255,12 +255,18 @@ class DaplaDocumentationMagics(Magics):
                              .format(key, binding_key, json.dumps(binding, indent=2)))
 
     def create_text_input(self, binding, key):
+        value = binding[key]
         if key == 'description':
+            if len(value) == 0 \
+                    and binding.__contains__('smart-description') \
+                    and binding['smart-description'] is not None:
+                value = binding['smart-description']
+                self._is_smart_match = 'sm'
             component = widgets.Textarea()
         else:
             component = widgets.Text()
 
-        component.value = binding[key]
+        component.value = value
 
         def on_change(v):
             binding[key] = v['new']

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -299,15 +299,15 @@ class DaplaDocumentationMagics(Magics):
             if cand['id'] == selected_id:
                 return selected_id
 
+        if selected_id != "":  # we have an id but it have been removed from candidates (Concept-lds)
+            self._status = '{}" is removed! please make a new selection'.format(selected_id)
+
         # add please select to candidates and make this selected
         candidates.append({
             'id': 'please-select',
             'name': 'please select'
         })
         first = 'please-select'  # candidates[0]['id']
-
-        if selected_id != "":  # we have an id but it have been removed from candidates (Concept-lds)
-            self._status = '{}" is removed! selecting:{}'.format(selected_id, first)
 
         return first
 
@@ -316,7 +316,7 @@ class DaplaDocumentationMagics(Magics):
         binding_key = binding[key]
         candidates = []
         selected_id = binding_key['selected-id']
-        if binding_key.__contains__('smart-match-id') and binding_key['smart-match-id'] != "unknown":
+        if binding_key.__contains__('smart-match-id') and binding_key['smart-match-id'] != "":
             smart_match_id = binding_key['smart-match-id']
             selected_id = smart_match_id  # TODO: show this on control
             self._is_smart_match = 'sm'

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -280,10 +280,19 @@ class DaplaDocumentationMagics(Magics):
 
     def create_enum_selector(self, binding, key):
         component = widgets.Dropdown()
-        component.options = binding[key]['enums']
+        enums = binding[key]['enums']
         key_selected_enum = binding[key]['selected-enum']
-        if key_selected_enum == "":
-            key_selected_enum = "MEASURE"
+        if key_selected_enum == '' \
+                and binding[key].__contains__('smart-enum') \
+                and binding[key]['smart-enum'] is not None:
+            key_selected_enum = binding[key]['smart-enum']
+            self._is_smart_match = 'sm'
+
+        if key_selected_enum == '':
+            key_selected_enum = 'please select'
+            enums.insert(0, 'please select')
+
+        component.options = enums
         component.value = key_selected_enum
 
         def on_change(v):

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -86,6 +86,41 @@ class DaplaDocumentationMagics(Magics):
         return find_dataset_path(dataset_name)
 
     @line_magic
+    def validate(self, dataset_name):
+        """For validating documentation
+        """
+        try:
+            ds = self.shell.user_ns[dataset_name]
+        except KeyError:
+            raise UsageError("Could not find variable name '{}'".format(dataset_name))
+
+        if not isinstance(ds, DataFrame):
+            raise UsageError("The variable '{}' is not a pyspark DataFrame".format(dataset_name))
+
+        self.validate_documentation(ds.doc)
+
+    def validate_documentation(self, doc):
+        def capitalize_with_camelcase(s):
+            return s[0].upper() + s[1:]
+
+        variable_titles = []
+        for instance_var in doc['instanceVariables']:
+            camelcase = capitalize_with_camelcase(instance_var['name'])
+            variable_titles.append(camelcase)
+            items = []
+            self.display(widgets.HTML('name: {}'.format(camelcase)))
+
+            for key in instance_var.keys():
+                if key == 'name' or key == 'smart-description':
+                    continue
+                items.append(
+                    key
+                )
+
+        # self.display(widgets.HTML('Create a validation test 2 report <i>{}</i>'.format(dataset_name)))
+        #return 'Create a validation report {}'.format(dataset_name)
+
+    @line_magic
     def document(self, line):
         """This line magic assists creating documentation metadata for a given variable_name. The variable_name must be
         resolved to a Spark DataFrame.

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -61,6 +61,9 @@ def remove_not_selected(doc_json):
             if variable[t].__contains__('smart-match-id'):
                 del variable[t]['smart-match-id']
 
+        if variable.__contains__('smart-description'):
+            del variable['smart-description']
+
         return variable['description'] is not None and variable['description'] != ''
 
     def map_variable(variable):

--- a/dapla/magics/lineage.py
+++ b/dapla/magics/lineage.py
@@ -108,7 +108,7 @@ class DaplaLineageMagics(Magics):
             self._show_warning_input = True
         elif any(x in line for x in ['off', 'False', '0']):
             self._show_warning_input = False
-        elif line is not '':
+        elif line != '':
             self.display(HTML("Unrecognized option: {}".format(line)))
         self.display(HTML("Show input declaration warnings: <b>{}</b>".format(self._show_warning_input)))
 
@@ -122,7 +122,7 @@ class DaplaLineageMagics(Magics):
             self._show_warning_output = True
         elif any(x in line for x in ['off', 'False', '0']):
             self._show_warning_output = False
-        elif line is not '':
+        elif line != '':
             self.display(HTML("Unrecognized option: {}".format(line)))
         self.display(HTML("Show output declaration warnings: <b>{}</b>".format(self._show_warning_output)))
 

--- a/dapla/magics/lineage.py
+++ b/dapla/magics/lineage.py
@@ -45,6 +45,10 @@ def extract_lineage(df, path, version):
             return None
 
 
+def find_dataset_path(name):
+    return get_ipython().run_line_magic(DaplaLineageMagics.find_output_path_for_dataset.__name__, "{}".format(name))
+
+
 def map_lineage(lineage_json):
     def mapper(field):
         return {
@@ -121,6 +125,14 @@ class DaplaLineageMagics(Magics):
             if line.strip().startswith('#'):
                 continue
             self._declared_outputs[line] = {}
+
+    @line_magic
+    def find_output_path_for_dataset(self, line):
+        for key in self._declared_outputs:
+            name = key.split('/')[-1]
+            if name == line:
+                return key
+        raise UsageError("output need to be declared for " + line)
 
     @line_magic
     def on_input_load(self, line):

--- a/dapla/services/clients.py
+++ b/dapla/services/clients.py
@@ -144,6 +144,16 @@ class DatasetDocClient(AbstractClient):
         handle_error_codes(response)
         return response.json()
 
+    def get_doc_enums(self, concept_type, enum_type):
+        request_url = self._base_url + '/doc/enums/' + concept_type + '/' + enum_type
+        response = requests.get(request_url,
+                                headers={
+                                    'Authorization': 'Bearer %s' % self._user_token_provider()
+                                }, allow_redirects=False)
+        handle_error_codes(response)
+        return response.json()
+
+
     def get_doc_validation(self, spark_schema, doc_template):
         request_url = self._base_url + '/doc/validate'
         request = {

--- a/dapla/services/clients.py
+++ b/dapla/services/clients.py
@@ -104,12 +104,13 @@ class MetadataPublisherClient(AbstractClient):
 
 class DatasetDocClient(AbstractClient):
 
-    def get_doc_template(self, spark_schema, use_simple):
+    def get_doc_template(self, spark_schema, use_simple, datasetPath):
         request_url = self._base_url + '/doc/template'
         request = {
             "schema": spark_schema,
             "schemaType": "SPARK",
-            "useSimpleFiltering": use_simple
+            "useSimpleFiltering": use_simple,
+            "datasetPath": datasetPath
         }
         response = requests.post(request_url, json=request,
                                  headers={

--- a/dapla/spark/decorators.py
+++ b/dapla/spark/decorators.py
@@ -47,9 +47,11 @@ def validate_documentation(write_method):
         schema = self._df.schema.json()
         validation = data_doc_client.get_doc_validation(schema, template_doc)
         status = validation['status']
-        if status == 'ok':
-            return write_method(self, ns)
         message = validation['message']
+        if status == 'ok':
+            if message != '':
+                print(message)
+            return write_method(self, ns)
         raise UsageError("{}".format(message))
     return wrapper
 

--- a/examples/dapla_doc_magics.ipynb
+++ b/examples/dapla_doc_magics.ipynb
@@ -89,9 +89,9 @@
     "\n",
     "\n",
     "# Register dapla magics manually\n",
-    "magics = DaplaDocumentationMagics(ipython, doc_template_mock, doc_template_candidates_mock)\n",
+    "magics_doc = DaplaDocumentationMagics(ipython, doc_template_mock, doc_template_candidates_mock)\n",
     "magics_lineage = DaplaLineageMagics(ipython, doc_template_candidates_mock)\n",
-    "ipython.register_magics(magics)\n",
+    "ipython.register_magics(magics_doc)\n",
     "ipython.register_magics(magics_lineage)"
    ],
    "metadata": {
@@ -129,6 +129,45 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "outputs": [],
+   "source": [
+    "%%output\n",
+    "/skatt/konto"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'/skatt/konto'"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Test that we can use linage magic\n",
+    "%find_path konto\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "outputs": [
     {
      "data": {
@@ -136,7 +175,7 @@
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "3c5b3ea6bdc849b7822ae534b3efcbcb"
+       "model_id": "eb87c415c4be4a6ca15dc9574af20d3c"
       }
      },
      "metadata": {},

--- a/examples/dapla_doc_magics.ipynb
+++ b/examples/dapla_doc_magics.ipynb
@@ -147,35 +147,11 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "'/skatt/konto'"
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Test that we can use linage magic\n",
-    "%find_path konto\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "outputs": [
-    {
-     "data": {
       "text/plain": "VBox(children=(HTML(value='<b style=\"font-size:14px\">Dataset metadata</b>'), Box(children=(Box(children=(Label…",
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "eb87c415c4be4a6ca15dc9574af20d3c"
+       "model_id": "8532c2eb6d5549c4a341a45e04cd2e3b"
       }
      },
      "metadata": {},
@@ -195,13 +171,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "outputs": [
     {
      "data": {
-      "text/plain": "{'name': 'konto datasett demo',\n 'description': 'Inneholder kontoer av forskjellig art.',\n 'unitType': {'concept-type': 'UnitType',\n  'selected-id': 'UnitType_DUMMY',\n  'candidates': [{'id': 'id-1', 'name': 'Test 1'},\n   {'id': 'UnitType_DUMMY', 'name': 'Test 2'}]},\n 'instanceVariables': [{'name': 'kontonummer',\n   'description': 'vilkårlig lang sekvens av tegn inkludert aksenter og spesielle tegn fra standardiserte tegnsett',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'id-2',\n    'smart-match-id': 'id-2',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'innskudd',\n   'description': '9 sifret nummer gitt de som er registrert i Enhetsregisteret.',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'DescribedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'gjeld',\n   'description': 'en sum av penger i hele kroner brukt i en kontekst. Dette kan være en transaksjon, saldo o.l.',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}}]}"
+      "text/plain": "HTML(value='name: Kontonummer')",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "b8dcff8966c34ea4a9632759b37fe09d"
+      }
      },
-     "execution_count": 5,
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": "HTML(value='name: Innskudd')",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "38b70f07060f4d1aac1fa990a3c8c650"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": "HTML(value='name: Gjeld')",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "181e51e0b4b14227a86000c8c05ab1d5"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%validate konto"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'name': 'konto datasett demo',\n 'description': 'Inneholder kontoer av forskjellig art.',\n 'unitType': {'concept-type': 'UnitType',\n  'selected-id': 'UnitType_DUMMY',\n  'candidates': [{'id': 'id-1', 'name': 'Test 1'},\n   {'id': 'UnitType_DUMMY', 'name': 'Test 2'}]},\n 'instanceVariables': [{'name': 'kontonummer',\n   'description': '',\n   'smart-description': 'smart-description',\n   'dataStructureComponentType': {'selected-enum': '',\n    'smart-enum': 'IDENTIFIER',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'smart-match-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'id-2',\n    'smart-match-id': 'id-2',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'smart-match-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'innskudd',\n   'description': '',\n   'dataStructureComponentType': {'selected-enum': '',\n    'enums': ['please select', 'IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'please-select',\n    'candidates': [{'id': 'please-select', 'name': 'please select'},\n     {'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'please-select',\n    'candidates': [{'id': 'please-select', 'name': 'please select'},\n     {'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'please-select',\n    'candidates': [{'id': 'please-select', 'name': 'please select'},\n     {'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'gjeld',\n   'description': 'en sum av penger i hele kroner brukt i en kontekst. Dette kan være en transaksjon, saldo o.l.',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}}]}"
+     },
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/dapla_doc_magics.ipynb
+++ b/examples/dapla_doc_magics.ipynb
@@ -84,12 +84,16 @@
     "           }\n",
     "       ]\n",
     "\n",
-    "\n",
     "    return []\n",
+    "\n",
+    "def doc_enums_mock(type, enumType):\n",
+    "        if enumType == \"dataStructureComponentType\":\n",
+    "            return [\"IDENTIFIER\", \"MEASURE\", \"ATTRIBUTE\", \"START_TIME\", \"STOP_TIME\"]\n",
+    "\n",
     "\n",
     "\n",
     "# Register dapla magics manually\n",
-    "magics_doc = DaplaDocumentationMagics(ipython, doc_template_mock, doc_template_candidates_mock)\n",
+    "magics_doc = DaplaDocumentationMagics(ipython, doc_template_mock, doc_template_candidates_mock, doc_enums_mock)\n",
     "magics_lineage = DaplaLineageMagics(ipython, doc_template_candidates_mock)\n",
     "ipython.register_magics(magics_doc)\n",
     "ipython.register_magics(magics_lineage)"
@@ -151,7 +155,7 @@
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "8532c2eb6d5549c4a341a45e04cd2e3b"
+       "model_id": "39449744c9564e709a245794d9415a05"
       }
      },
      "metadata": {},
@@ -160,7 +164,7 @@
    ],
    "source": [
     "# Now run the magic\n",
-    "%document --nofile konto"
+    "%document -f konto_with_smart.json konto"
    ],
    "metadata": {
     "collapsed": false,
@@ -175,11 +179,11 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "HTML(value='name: Kontonummer')",
+      "text/plain": "HTML(value='<b>Kontonummer</b> <i>smart</i>')",
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "b8dcff8966c34ea4a9632759b37fe09d"
+       "model_id": "ad7f1785ec554a5c88c5a7dd281546b1"
       }
      },
      "metadata": {},
@@ -187,11 +191,11 @@
     },
     {
      "data": {
-      "text/plain": "HTML(value='name: Innskudd')",
+      "text/plain": "HTML(value='<b>Innskudd</b> <i>not selected</i>')",
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "38b70f07060f4d1aac1fa990a3c8c650"
+       "model_id": "db6e6a1a258540569468833fb0621350"
       }
      },
      "metadata": {},
@@ -199,11 +203,11 @@
     },
     {
      "data": {
-      "text/plain": "HTML(value='name: Gjeld')",
+      "text/plain": "HTML(value='<b>Gjeld</b> <i>ok</i>')",
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "181e51e0b4b14227a86000c8c05ab1d5"
+       "model_id": "26ed9c19eab948fd8e51a2151b8ce700"
       }
      },
      "metadata": {},
@@ -226,7 +230,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "{'name': 'konto datasett demo',\n 'description': 'Inneholder kontoer av forskjellig art.',\n 'unitType': {'concept-type': 'UnitType',\n  'selected-id': 'UnitType_DUMMY',\n  'candidates': [{'id': 'id-1', 'name': 'Test 1'},\n   {'id': 'UnitType_DUMMY', 'name': 'Test 2'}]},\n 'instanceVariables': [{'name': 'kontonummer',\n   'description': '',\n   'smart-description': 'smart-description',\n   'dataStructureComponentType': {'selected-enum': '',\n    'smart-enum': 'IDENTIFIER',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'smart-match-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'id-2',\n    'smart-match-id': 'id-2',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'smart-match-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'innskudd',\n   'description': '',\n   'dataStructureComponentType': {'selected-enum': '',\n    'enums': ['please select', 'IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'please-select',\n    'candidates': [{'id': 'please-select', 'name': 'please select'},\n     {'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'please-select',\n    'candidates': [{'id': 'please-select', 'name': 'please select'},\n     {'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'please-select',\n    'candidates': [{'id': 'please-select', 'name': 'please select'},\n     {'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'gjeld',\n   'description': 'en sum av penger i hele kroner brukt i en kontekst. Dette kan være en transaksjon, saldo o.l.',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}}]}"
+      "text/plain": "{'name': 'konto datasett demo',\n 'description': 'Inneholder kontoer av forskjellig art.',\n 'unitType': {'concept-type': 'UnitType',\n  'selected-id': 'UnitType_DUMMY',\n  'candidates': [{'id': 'id-1', 'name': 'Test 1'},\n   {'id': 'UnitType_DUMMY', 'name': 'Test 2'}]},\n 'instanceVariables': [{'name': 'kontonummer',\n   'description': '',\n   'smart-description': 'smart-description',\n   'dataStructureComponentType': {'selected-enum': 'IDENTIFIER',\n    'smart-enum': 'IDENTIFIER',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'smart-match-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'id-2',\n    'smart-match-id': 'id-2',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'smart-match-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'innskudd',\n   'description': '',\n   'dataStructureComponentType': {'selected-enum': '',\n    'enums': ['please select',\n     'please select',\n     'IDENTIFIER',\n     'MEASURE',\n     'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'please-select',\n    'candidates': [{'id': 'please-select', 'name': 'please select'},\n     {'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'please-select',\n    'candidates': [{'id': 'please-select', 'name': 'please select'},\n     {'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'please-select',\n    'candidates': [{'id': 'please-select', 'name': 'please select'},\n     {'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'gjeld',\n   'description': 'en sum av penger i hele kroner brukt i en kontekst. Dette kan være en transaksjon, saldo o.l.',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}}]}"
      },
      "execution_count": 9,
      "metadata": {},

--- a/examples/dapla_doc_magics.ipynb
+++ b/examples/dapla_doc_magics.ipynb
@@ -20,13 +20,14 @@
    "source": [
     "# Initialise test environment\n",
     "from dapla.magics import DaplaDocumentationMagics\n",
+    "from dapla.magics import DaplaLineageMagics\n",
     "from IPython import get_ipython\n",
     "ipython = get_ipython()\n",
     "\n",
     "# Provide a mock template from attached json file\n",
     "import json\n",
-    "def doc_template_mock(ds, use_simple):\n",
-    "    with open('doc-template.json', 'r') as f:\n",
+    "def doc_template_mock(ds, use_simple, path):\n",
+    "    with open('doc_template_with_smart_match.json', 'r') as f:\n",
     "        return json.load(f)\n",
     "\n",
     "def doc_template_candidates_mock(type):\n",
@@ -50,6 +51,10 @@
     "           {\n",
     "               'id': 'id-2',\n",
     "               'name': 'Test 2'\n",
+    "           },\n",
+    "           {\n",
+    "               'id': 'some-id-could-be-guid',\n",
+    "               'name': 'All families 2018'\n",
     "           }\n",
     "       ]\n",
     "    if type == \"population\":\n",
@@ -72,6 +77,10 @@
     "           {\n",
     "               'id': 'DescribedValueDomain-id1',\n",
     "               'name': 'DescribedValueDomain Test 2'\n",
+    "           },\n",
+    "           {\n",
+    "               'id': 'DescribedValueDomain_DUMMY-id',\n",
+    "               'name': 'DescribedValueDomain DUMMY'\n",
     "           }\n",
     "       ]\n",
     "\n",
@@ -81,7 +90,9 @@
     "\n",
     "# Register dapla magics manually\n",
     "magics = DaplaDocumentationMagics(ipython, doc_template_mock, doc_template_candidates_mock)\n",
-    "ipython.register_magics(magics)"
+    "magics_lineage = DaplaLineageMagics(ipython, doc_template_candidates_mock)\n",
+    "ipython.register_magics(magics)\n",
+    "ipython.register_magics(magics_lineage)"
    ],
    "metadata": {
     "collapsed": false,
@@ -125,7 +136,7 @@
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "bc1366febf1041e1afc122884c064f1a"
+       "model_id": "3c5b3ea6bdc849b7822ae534b3efcbcb"
       }
      },
      "metadata": {},
@@ -134,7 +145,7 @@
    ],
    "source": [
     "# Now run the magic\n",
-    "%document -f doc-template.json konto"
+    "%document --nofile konto"
    ],
    "metadata": {
     "collapsed": false,
@@ -149,7 +160,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "{'name': 'konto datasett demo',\n 'description': 'Inneholder kontoer av forskjellig art.',\n 'unitType': {'concept-type': 'UnitType',\n  'selected-id': 'UnitType_DUMMY',\n  'candidates': [{'id': 'some-id-could-be-guid', 'name': 'Heltall'},\n   {'id': 'UnitType_DUMMY', 'name': 'UnitType_default'}]},\n 'instanceVariables': [{'name': 'kontonummer',\n   'description': 'vilkårlig lang sekvens av tegn inkludert aksenter og spesielle tegn fra standardiserte tegnsett',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'some-id-could-be-guid',\n      'name': 'All families 2018-01-01'},\n     {'id': 'Population_DUMMY', 'name': 'Population_default'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'some-id-could-be-guid',\n      'name': 'NationalFamilyIdentifier'},\n     {'id': 'RepresentedVariable_DUMMY',\n      'name': 'RepresentedVariable_default'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain_default'},\n     {'id': 'some-id-could-be-guid', 'name': 'Heltall'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain_DUMMY'}]}},\n  {'name': 'innskudd',\n   'description': '9 sifret nummer gitt de som er registrert i Enhetsregisteret.',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'some-id-could-be-guid',\n      'name': 'All families 2018-01-01'},\n     {'id': 'Population_DUMMY', 'name': 'Population_default'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'some-id-could-be-guid',\n      'name': 'NationalFamilyIdentifier'},\n     {'id': 'RepresentedVariable_DUMMY',\n      'name': 'RepresentedVariable_default'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'DescribedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain_default'},\n     {'id': 'some-id-could-be-guid', 'name': 'Heltall'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain_DUMMY'}]}},\n  {'name': 'gjeld',\n   'description': 'en sum av penger i hele kroner brukt i en kontekst. Dette kan være en transaksjon, saldo o.l.',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'some-id-could-be-guid',\n      'name': 'All families 2018-01-01'},\n     {'id': 'Population_DUMMY', 'name': 'Population_default'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'some-id-could-be-guid',\n      'name': 'NationalFamilyIdentifier'},\n     {'id': 'RepresentedVariable_DUMMY',\n      'name': 'RepresentedVariable_default'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain_default'},\n     {'id': 'some-id-could-be-guid', 'name': 'Heltall'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain_DUMMY'}]}}]}"
+      "text/plain": "{'name': 'konto datasett demo',\n 'description': 'Inneholder kontoer av forskjellig art.',\n 'unitType': {'concept-type': 'UnitType',\n  'selected-id': 'UnitType_DUMMY',\n  'candidates': [{'id': 'id-1', 'name': 'Test 1'},\n   {'id': 'UnitType_DUMMY', 'name': 'Test 2'}]},\n 'instanceVariables': [{'name': 'kontonummer',\n   'description': 'vilkårlig lang sekvens av tegn inkludert aksenter og spesielle tegn fra standardiserte tegnsett',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'id-2',\n    'smart-match-id': 'id-2',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'innskudd',\n   'description': '9 sifret nummer gitt de som er registrert i Enhetsregisteret.',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'DescribedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}},\n  {'name': 'gjeld',\n   'description': 'en sum av penger i hele kroner brukt i en kontekst. Dette kan være en transaksjon, saldo o.l.',\n   'dataStructureComponentType': {'selected-enum': 'MEASURE',\n    'enums': ['IDENTIFIER', 'MEASURE', 'ATTRIBUTE']},\n   'population': {'concept-type': 'Population',\n    'selected-id': 'Population_DUMMY',\n    'candidates': [{'id': 'Population_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'}]},\n   'representedVariable': {'concept-type': 'RepresentedVariable',\n    'selected-id': 'RepresentedVariable_DUMMY',\n    'candidates': [{'id': 'RepresentedVariable_DUMMY', 'name': 'Test 1'},\n     {'id': 'id-2', 'name': 'Test 2'},\n     {'id': 'some-id-could-be-guid', 'name': 'All families 2018'}]},\n   'sentinelValueDomain': {'concept-type': 'EnumeratedValueDomain,DescribedValueDomain',\n    'selected-id': 'EnumeratedValueDomain_DUMMY-id',\n    'candidates': [{'id': 'EnumeratedValueDomain_DUMMY-id',\n      'name': 'EnumeratedValueDomain Test 1'},\n     {'id': 'DescribedValueDomain-id1', 'name': 'DescribedValueDomain Test 2'},\n     {'id': 'DescribedValueDomain_DUMMY-id',\n      'name': 'DescribedValueDomain DUMMY'}]}}]}"
      },
      "execution_count": 5,
      "metadata": {},

--- a/examples/dapla_lineage_magics.ipynb
+++ b/examples/dapla_lineage_magics.ipynb
@@ -200,11 +200,11 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "Accordion(children=(VBox(children=(HTML(value='<style>.widget-checkbox-label-bold > label > span {font-weight:…",
+      "text/plain": "VBox(children=(Accordion(children=(VBox(children=(HTML(value='<style>.widget-checkbox-label-bold > label > spa…",
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "a2176d1c54ef49b69348a1c330214a9e"
+       "model_id": "f7a24081ccda4814a12478fd929e5252"
       }
      },
      "metadata": {},
@@ -258,8 +258,20 @@
    "source": [
     "# Return simple lineage template by path\n",
     "\n",
-    "%lineage_json --path /skatt/innskudd\n"
+    "%lineage_json --path /skatt/innskudd"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   }
  ],
  "metadata": {

--- a/examples/doc_template_with_smart_match.json
+++ b/examples/doc_template_with_smart_match.json
@@ -41,9 +41,9 @@
     },
     {
       "name": "innskudd",
-      "description": "9 sifret nummer gitt de som er registrert i Enhetsregisteret.",
+      "description": "",
       "dataStructureComponentType": {
-        "selected-enum": "MEASURE",
+        "selected-enum": "",
         "enums": [
           "IDENTIFIER",
           "MEASURE",
@@ -52,17 +52,17 @@
       },
       "population": {
         "concept-type": "Population",
-        "selected-id": "Population_DUMMY",
+        "selected-id": "",
         "candidates": []
       },
       "representedVariable": {
         "concept-type": "RepresentedVariable",
-        "selected-id": "RepresentedVariable_DUMMY",
+        "selected-id": "",
         "candidates": []
       },
       "sentinelValueDomain": {
         "concept-type": "EnumeratedValueDomain,DescribedValueDomain",
-        "selected-id": "DescribedValueDomain_DUMMY-id",
+        "selected-id": "",
         "candidates": []
       }
     },

--- a/examples/doc_template_with_smart_match.json
+++ b/examples/doc_template_with_smart_match.json
@@ -9,9 +9,11 @@
   "instanceVariables": [
     {
       "name": "kontonummer",
-      "description": "vilk\u00e5rlig lang sekvens av tegn inkludert aksenter og spesielle tegn fra standardiserte tegnsett",
+      "description": "",
+      "smart-description": "smart-description",
       "dataStructureComponentType": {
-        "selected-enum": "MEASURE",
+        "selected-enum": "",
+        "smart-enum": "IDENTIFIER",
         "enums": [
           "IDENTIFIER",
           "MEASURE",
@@ -20,17 +22,20 @@
       },
       "population": {
         "concept-type": "Population",
-        "selected-id": "Population_DUMMY",
+        "selected-id": "",
+        "smart-match-id": "Population_DUMMY",
         "candidates": []
       },
       "representedVariable": {
         "concept-type": "RepresentedVariable",
-        "selected-id": "some-id-could-be-guid",
+        "selected-id": "",
+        "smart-match-id": "id-2",
         "candidates": []
       },
       "sentinelValueDomain": {
         "concept-type": "EnumeratedValueDomain,DescribedValueDomain",
-        "selected-id": "EnumeratedValueDomain_DUMMY-id",
+        "selected-id": "",
+        "smart-match-id": "EnumeratedValueDomain_DUMMY-id",
         "candidates": []
       }
     },

--- a/examples/doc_template_with_smart_match.json
+++ b/examples/doc_template_with_smart_match.json
@@ -1,0 +1,114 @@
+{
+  "name": "konto datasett demo",
+  "description": "Inneholder kontoer av forskjellig art.",
+  "unitType": {
+    "concept-type": "UnitType",
+    "selected-id": "UnitType_DUMMY",
+    "candidates": []
+  },
+  "instanceVariables": [
+    {
+      "name": "kontonummer",
+      "description": "vilk\u00e5rlig lang sekvens av tegn inkludert aksenter og spesielle tegn fra standardiserte tegnsett",
+      "dataStructureComponentType": {
+        "selected-enum": "MEASURE",
+        "enums": [
+          "IDENTIFIER",
+          "MEASURE",
+          "ATTRIBUTE"
+        ]
+      },
+      "population": {
+        "concept-type": "Population",
+        "selected-id": "Population_DUMMY",
+        "candidates": []
+      },
+      "representedVariable": {
+        "concept-type": "RepresentedVariable",
+        "selected-id": "some-id-could-be-guid",
+        "candidates": []
+      },
+      "sentinelValueDomain": {
+        "concept-type": "EnumeratedValueDomain,DescribedValueDomain",
+        "selected-id": "EnumeratedValueDomain_DUMMY-id",
+        "candidates": []
+      }
+    },
+    {
+      "name": "innskudd",
+      "description": "9 sifret nummer gitt de som er registrert i Enhetsregisteret.",
+      "dataStructureComponentType": {
+        "selected-enum": "MEASURE",
+        "enums": [
+          "IDENTIFIER",
+          "MEASURE",
+          "ATTRIBUTE"
+        ]
+      },
+      "population": {
+        "concept-type": "Population",
+        "selected-id": "Population_DUMMY",
+        "candidates": []
+      },
+      "representedVariable": {
+        "concept-type": "RepresentedVariable",
+        "selected-id": "RepresentedVariable_DUMMY",
+        "candidates": []
+      },
+      "sentinelValueDomain": {
+        "concept-type": "EnumeratedValueDomain,DescribedValueDomain",
+        "selected-id": "DescribedValueDomain_DUMMY-id",
+        "candidates": []
+      }
+    },
+    {
+      "name": "gjeld",
+      "description": "en sum av penger i hele kroner brukt i en kontekst. Dette kan v\u00e6re en transaksjon, saldo o.l.",
+      "dataStructureComponentType": {
+        "selected-enum": "MEASURE",
+        "enums": [
+          "IDENTIFIER",
+          "MEASURE",
+          "ATTRIBUTE"
+        ]
+      },
+      "population": {
+        "concept-type": "Population",
+        "selected-id": "Population_DUMMY",
+        "candidates": []
+      },
+      "representedVariable": {
+        "concept-type": "RepresentedVariable",
+        "selected-id": "RepresentedVariable_DUMMY",
+        "candidates": [
+          {
+            "id": "some-id-could-be-guid",
+            "name": "NationalFamilyIdentifier"
+          },
+          {
+            "id": "RepresentedVariable_DUMMY",
+            "name": "RepresentedVariable_default"
+          }
+        ]
+      },
+      "sentinelValueDomain": {
+        "concept-type": "EnumeratedValueDomain,DescribedValueDomain",
+        "selected-id": "EnumeratedValueDomain_DUMMY-id",
+        "candidates": [
+          {
+            "id": "EnumeratedValueDomain_DUMMY-id",
+            "name": "EnumeratedValueDomain_default"
+          },
+          {
+            "id": "some-id-could-be-guid",
+            "name": "Heltall"
+          },
+          {
+            "id": "DescribedValueDomain_DUMMY-id",
+            "name": "DescribedValueDomain_DUMMY"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/doc_with_smart_template.json
+++ b/tests/doc_with_smart_template.json
@@ -1,0 +1,224 @@
+{
+  "name": "konto datasett demo",
+  "description": "Inneholder kontoer av forskjellig art.",
+  "unitType": {
+    "concept-type": "UnitType",
+    "selected-id": "UnitType_DUMMY",
+    "candidates": [
+      {
+        "id": "id-1",
+        "name": "Test 1"
+      },
+      {
+        "id": "UnitType_DUMMY",
+        "name": "Test 2"
+      }
+    ]
+  },
+  "instanceVariables": [
+    {
+      "name": "kontonummer",
+      "description": "kontonummer desc",
+      "smart-description": "smart-description",
+      "dataStructureComponentType": {
+        "selected-enum": "IDENTIFIER",
+        "smart-enum": "IDENTIFIER",
+        "enums": [
+          "IDENTIFIER",
+          "MEASURE",
+          "ATTRIBUTE"
+        ]
+      },
+      "population": {
+        "concept-type": "Population",
+        "selected-id": "Population_DUMMY",
+        "smart-match-id": "Population_DUMMY",
+        "candidates": [
+          {
+            "id": "Population_DUMMY",
+            "name": "Test 1"
+          },
+          {
+            "id": "id-2",
+            "name": "Test 2"
+          }
+        ]
+      },
+      "representedVariable": {
+        "concept-type": "RepresentedVariable",
+        "selected-id": "some-id-could-be-guid",
+        "smart-match-id": "id-2",
+        "candidates": [
+          {
+            "id": "RepresentedVariable_DUMMY",
+            "name": "Test 1"
+          },
+          {
+            "id": "id-2",
+            "name": "Test 2"
+          },
+          {
+            "id": "some-id-could-be-guid",
+            "name": "All families 2018"
+          }
+        ]
+      },
+      "sentinelValueDomain": {
+        "concept-type": "EnumeratedValueDomain,DescribedValueDomain",
+        "selected-id": "EnumeratedValueDomain_DUMMY-id",
+        "smart-match-id": "EnumeratedValueDomain_DUMMY-id",
+        "candidates": [
+          {
+            "id": "EnumeratedValueDomain_DUMMY-id",
+            "name": "EnumeratedValueDomain Test 1"
+          },
+          {
+            "id": "DescribedValueDomain-id1",
+            "name": "DescribedValueDomain Test 2"
+          },
+          {
+            "id": "DescribedValueDomain_DUMMY-id",
+            "name": "DescribedValueDomain DUMMY"
+          }
+        ]
+      }
+    },
+    {
+      "name": "innskudd",
+      "description": "innskudd desc",
+      "dataStructureComponentType": {
+        "selected-enum": "",
+        "enums": [
+          "please select",
+          "IDENTIFIER",
+          "MEASURE",
+          "ATTRIBUTE"
+        ]
+      },
+      "population": {
+        "concept-type": "Population",
+        "selected-id": "please-select",
+        "candidates": [
+          {
+            "id": "please-select",
+            "name": "please select"
+          },
+          {
+            "id": "Population_DUMMY",
+            "name": "Test 1"
+          },
+          {
+            "id": "id-2",
+            "name": "Test 2"
+          }
+        ]
+      },
+      "representedVariable": {
+        "concept-type": "RepresentedVariable",
+        "selected-id": "please-select",
+        "candidates": [
+          {
+            "id": "please-select",
+            "name": "please select"
+          },
+          {
+            "id": "RepresentedVariable_DUMMY",
+            "name": "Test 1"
+          },
+          {
+            "id": "id-2",
+            "name": "Test 2"
+          },
+          {
+            "id": "some-id-could-be-guid",
+            "name": "All families 2018"
+          }
+        ]
+      },
+      "sentinelValueDomain": {
+        "concept-type": "EnumeratedValueDomain,DescribedValueDomain",
+        "selected-id": "please-select",
+        "candidates": [
+          {
+            "id": "please-select",
+            "name": "please select"
+          },
+          {
+            "id": "EnumeratedValueDomain_DUMMY-id",
+            "name": "EnumeratedValueDomain Test 1"
+          },
+          {
+            "id": "DescribedValueDomain-id1",
+            "name": "DescribedValueDomain Test 2"
+          },
+          {
+            "id": "DescribedValueDomain_DUMMY-id",
+            "name": "DescribedValueDomain DUMMY"
+          }
+        ]
+      }
+    },
+    {
+      "name": "gjeld",
+      "description": "en sum av penger i hele kroner brukt i en kontekst. Dette kan v\u00e6re en transaksjon, saldo o.l.",
+      "dataStructureComponentType": {
+        "selected-enum": "MEASURE",
+        "enums": [
+          "IDENTIFIER",
+          "MEASURE",
+          "ATTRIBUTE"
+        ]
+      },
+      "population": {
+        "concept-type": "Population",
+        "selected-id": "Population_DUMMY",
+        "candidates": [
+          {
+            "id": "Population_DUMMY",
+            "name": "Test 1"
+          },
+          {
+            "id": "id-2",
+            "name": "Test 2"
+          }
+        ]
+      },
+      "representedVariable": {
+        "concept-type": "RepresentedVariable",
+        "selected-id": "RepresentedVariable_DUMMY",
+        "candidates": [
+          {
+            "id": "RepresentedVariable_DUMMY",
+            "name": "Test 1"
+          },
+          {
+            "id": "id-2",
+            "name": "Test 2"
+          },
+          {
+            "id": "some-id-could-be-guid",
+            "name": "All families 2018"
+          }
+        ]
+      },
+      "sentinelValueDomain": {
+        "concept-type": "EnumeratedValueDomain,DescribedValueDomain",
+        "selected-id": "EnumeratedValueDomain_DUMMY-id",
+        "candidates": [
+          {
+            "id": "EnumeratedValueDomain_DUMMY-id",
+            "name": "EnumeratedValueDomain Test 1"
+          },
+          {
+            "id": "DescribedValueDomain-id1",
+            "name": "DescribedValueDomain Test 2"
+          },
+          {
+            "id": "DescribedValueDomain_DUMMY-id",
+            "name": "DescribedValueDomain DUMMY"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -9,7 +9,7 @@ from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, StringType
 from IPython.core.error import UsageError
 
-from dapla.magics.documentation import DaplaDocumentationMagics, map_doc_output
+from dapla.magics.documentation import DaplaDocumentationMagics, map_doc_output, remove_not_selected
 from dapla.services.clients import DatasetDocClient
 from tests import resolve_filename
 
@@ -101,6 +101,16 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
 
         output = map_doc_output(doc_template)
         self.assertEqual(expected_doc, output)
+
+
+    def test_check_and_remove_output(self):
+        with open(resolve_filename('doc_with_smart_template.json'), 'r') as f:
+            doc_template = json.load(f)
+
+        doc_output = map_doc_output(doc_template)
+        output = remove_not_selected(doc_output)
+        print(json.dumps(output, indent=2))
+
 
     def test_check_selected_id(self):
         candidates = [

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -37,12 +37,16 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
                     {"id": "id3", "name": "name3"}
                 ]
 
+        def enums(type, enumType):
+            # if enumType == 'enums':
+            return ["VAL1", "VAL2", "VAL3"]
+
         doc_template_client = DatasetDocClient(lambda: 'mock-user-token', 'http://mock.no/')
         self._magic = DaplaDocumentationMagics(
             None,
             doc_template_client.get_doc_template,
-            candidates
-
+            candidates,
+            enums
             # TODO check and add more candidates based on type
         )
         self._magic.shell = MagicMock()
@@ -108,6 +112,8 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
             doc_template = json.load(f)
 
         doc_output = map_doc_output(doc_template)
+        # print(json.dumps(doc_output, indent=2))
+
         output = remove_not_selected(doc_output)
         print(json.dumps(output, indent=2))
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -168,22 +168,22 @@ doc_template = {
 }
 
 expected_widgets = "VBox(children=(HTML(value='<b style=\"font-size:14px\">Dataset metadata</b>'), \
-Box(children=(Box(children=(Label(value='Name'), Text(value='ds name'), HTML(value='')), \
+Box(children=(Box(children=(Label(value='Name'), Text(value='ds name')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
-Box(children=(Label(value='Description'), Textarea(value='ds description'), HTML(value='')), \
+Box(children=(Label(value='Description'), Textarea(value='ds description')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
-Box(children=(Label(value='UnitType'), Dropdown(options=(('UnitType_DUMMY', 'UnitType_DUMMY'),), value='UnitType_DUMMY'), HTML(value='')), \
+Box(children=(Label(value='UnitType'), Dropdown(options=(('UnitType_DUMMY', 'UnitType_DUMMY'),), value='UnitType_DUMMY')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between'))), \
 layout=Layout(align_items='stretch', display='flex', flex_flow='column', width='70%')), \
 HTML(value='<b style=\"font-size:14px\">Instance variables</b>'), \
 Accordion(children=(Box(children=(Box(children=(Label(value='Description'), \
-Textarea(value='iv1descr'), HTML(value='')), layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
-Box(children=(Label(value='CheckboxValue'), Checkbox(value=False, indent=False), HTML(value='')), \
+Textarea(value='iv1descr')), layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
+Box(children=(Label(value='CheckboxValue'), Checkbox(value=False, indent=False)), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
-Box(children=(Label(value='EnumValue'), Dropdown(index=1, options=('VAL1', 'VAL2', 'VAL3'), value='VAL2'), HTML(value='')), \
+Box(children=(Label(value='EnumValue'), Dropdown(index=1, options=('VAL1', 'VAL2', 'VAL3'), value='VAL2')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
 Box(children=(Label(value='SelectionValue'), \
-Dropdown(index=2, options=(('name1', 'id1'), ('name2', 'id2'), ('name3', 'id3')), value='id3'), HTML(value='')), \
+Dropdown(index=2, options=(('name1', 'id1'), ('name2', 'id2'), ('name3', 'id3')), value='id3')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between'))), \
 layout=Layout(align_items='stretch', display='flex', flex_flow='column', width='70%')),), selected_index=None, \
 _titles={'0': 'Iv1'})))\n"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -25,14 +25,29 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
         cls._spark.sparkContext.stop()
 
     def setUp(self):
+        def candidates(a):
+            if a == 'unitType':
+                return [
+                    {'id': 'UnitType_DUMMY', 'name': 'UnitType_DUMMY'}
+                ]
+            if a == 'selectionValue':
+                return [
+                    {"id": "id1", "name": "name1"},
+                    {"id": "id2", "name": "name2"},
+                    {"id": "id3", "name": "name3"}
+                ]
+
         doc_template_client = DatasetDocClient(lambda: 'mock-user-token', 'http://mock.no/')
         self._magic = DaplaDocumentationMagics(
             None,
             doc_template_client.get_doc_template,
-            doc_template_client.get_doc_template_candidates
+            candidates
+
+            # TODO check and add more candidates based on type
         )
         self._magic.shell = MagicMock()
         self._magic.display = MagicMock()
+        self._magic.get_dataset_path = lambda a1: ''
 
         schema = StructType([
             StructField('variable1', StringType(), True)
@@ -101,7 +116,7 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
         self.assertEqual('id-1', self._magic.check_selected_id('type', candidates, 'id-1'))
         self.assertEqual('id-2', self._magic.check_selected_id('type', candidates, 'id-2'))
 
-        self.assertEqual('id-1', self._magic.check_selected_id('type', candidates, 'missing-id'))
+        self.assertEqual('please-select', self._magic.check_selected_id('type', candidates, 'missing-id'))
 
 
 doc_template = {
@@ -137,22 +152,22 @@ doc_template = {
 }
 
 expected_widgets = "VBox(children=(HTML(value='<b style=\"font-size:14px\">Dataset metadata</b>'), \
-Box(children=(Box(children=(Label(value='Name'), Text(value='ds name')), \
+Box(children=(Box(children=(Label(value='Name'), Text(value='ds name'), HTML(value='')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
-Box(children=(Label(value='Description'), Textarea(value='ds description')), \
+Box(children=(Label(value='Description'), Textarea(value='ds description'), HTML(value='')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
-Box(children=(Label(value='UnitType'), Dropdown(options=(('UnitType_DUMMY', 'UnitType_DUMMY'),), value='UnitType_DUMMY')), \
+Box(children=(Label(value='UnitType'), Dropdown(options=(('UnitType_DUMMY', 'UnitType_DUMMY'),), value='UnitType_DUMMY'), HTML(value='')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between'))), \
 layout=Layout(align_items='stretch', display='flex', flex_flow='column', width='70%')), \
 HTML(value='<b style=\"font-size:14px\">Instance variables</b>'), \
 Accordion(children=(Box(children=(Box(children=(Label(value='Description'), \
-Textarea(value='iv1descr')), layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
-Box(children=(Label(value='CheckboxValue'), Checkbox(value=False, indent=False)), \
+Textarea(value='iv1descr'), HTML(value='')), layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
+Box(children=(Label(value='CheckboxValue'), Checkbox(value=False, indent=False), HTML(value='')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
-Box(children=(Label(value='EnumValue'), Dropdown(index=1, options=('VAL1', 'VAL2', 'VAL3'), value='VAL2')), \
+Box(children=(Label(value='EnumValue'), Dropdown(index=1, options=('VAL1', 'VAL2', 'VAL3'), value='VAL2'), HTML(value='')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between')), \
 Box(children=(Label(value='SelectionValue'), \
-Dropdown(index=2, options=(('name1', 'id1'), ('name2', 'id2'), ('name3', 'id3')), value='id3')), \
+Dropdown(index=2, options=(('name1', 'id1'), ('name2', 'id2'), ('name3', 'id3')), value='id3'), HTML(value='')), \
 layout=Layout(display='flex', flex_flow='row', justify_content='space-between'))), \
 layout=Layout(align_items='stretch', display='flex', flex_flow='column', width='70%')),), selected_index=None, \
 _titles={'0': 'Iv1'})))\n"


### PR DESCRIPTION
Using smart matched from dataset-doc-service
Getting candidates and enums from dataset-doc-service
Adding 'please-select' and not just selecting first candidate from concept-lds
We now add documentation where not all instance variables is documented. (The one not documented is removed) 