### PR TITLE
Add support for optional documentation

### DIFF
--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -50,16 +50,31 @@ def map_doc_output(doc_json):
 
 def remove_not_selected(doc_json):
     def filter_not_selected_variables(variable):
-        if variable['dataStructureComponentType']['selected-enum'] == '':
-            return False
-        if variable['dataStructureComponentType'].__contains__('smart-enum'):
-            del variable['dataStructureComponentType']['smart-enum']
-        types = ('population', 'representedVariable', 'sentinelValueDomain')
-        for t in types:
-            if variable[t]['selected-id'] == 'please-select':
-                return False
-            if variable[t].__contains__('smart-match-id'):
-                del variable[t]['smart-match-id']
+        def is_enum(value):
+            return value.__contains__('selected-enum')
+
+        def has_smart_enum(value):
+            return value.__contains__('smart-enum')
+
+        def is_type(value):
+            return value.__contains__('concept-type')
+
+        def has_smart_id(value):
+            return value.__contains__('smart-match-id')
+
+        for key in variable.keys():
+            data = variable[key]
+            print("data for: " + key + " -> " + str(data))
+            if is_enum(data):
+                if data['selected-enum'] == '' or data['selected-enum'] == 'please-select':
+                    return False  # we are missing selection -> remove this
+                if has_smart_enum(data):
+                    del data['smart-enum']
+            if is_type(data):
+                if data['selected-id'] == '' or data['selected-id'] == 'please-select':
+                    return False  # we are missing selection > remove this
+                if has_smart_id(data):
+                    del data['smart-match-id']
 
         if variable.__contains__('smart-description'):
             del variable['smart-description']
@@ -162,7 +177,6 @@ class DaplaDocumentationMagics(Magics):
                     key
                 )
 
-
     @line_magic
     def document(self, line):
         """This line magic assists creating documentation metadata for a given variable_name. The variable_name must be
@@ -262,7 +276,7 @@ class DaplaDocumentationMagics(Magics):
             inst_dropdown = self.create_widget(dict, key)
             if self._status is None:
                 label = widgets.Label(value=get_title(title))
-                dropdown = [label, inst_dropdown] 
+                dropdown = [label, inst_dropdown]
                 self._is_smart_match = ''
             else:
                 label = widgets.Label(value=title)

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -63,7 +63,7 @@ def remove_not_selected(doc_json):
             return value.__contains__('smart-match-id')
 
         def is_optional(value):
-            return value.__contains__('optional') and value['optional'].lower() == 'true'
+            return value.__contains__('optional') and value['optional']
 
         def check_selection_value(selection_type):
             return data[selection_type] == '' or data[selection_type] == 'please-select'

--- a/dapla/magics/documentation.py
+++ b/dapla/magics/documentation.py
@@ -62,19 +62,34 @@ def remove_not_selected(doc_json):
         def has_smart_id(value):
             return value.__contains__('smart-match-id')
 
+        def is_optional(value):
+            return value.__contains__('optional') and value['optional'].lower() == 'true'
+
+        def check_selection_value(selection_type):
+            return data[selection_type] == '' or data[selection_type] == 'please-select'
+
+        to_delete = []
         for key in variable.keys():
             data = variable[key]
-            print("data for: " + key + " -> " + str(data))
             if is_enum(data):
-                if data['selected-enum'] == '' or data['selected-enum'] == 'please-select':
-                    return False  # we are missing selection -> remove this
+                if check_selection_value('selected-enum'):
+                    if is_optional(data):
+                        to_delete.append(key)
+                    else:
+                        return False  # we are missing selection -> remove this
                 if has_smart_enum(data):
                     del data['smart-enum']
             if is_type(data):
-                if data['selected-id'] == '' or data['selected-id'] == 'please-select':
-                    return False  # we are missing selection > remove this
+                if check_selection_value('selected-id'):
+                    if is_optional(data):
+                        to_delete.append(key)
+                    else:
+                        return False  # we are missing selection > remove this
                 if has_smart_id(data):
                     del data['smart-match-id']
+
+        for key in to_delete:
+            del variable[key]
 
         if variable.__contains__('smart-description'):
             del variable['smart-description']

--- a/examples/doc_template_with_smart_match.json
+++ b/examples/doc_template_with_smart_match.json
@@ -20,6 +20,15 @@
           "ATTRIBUTE"
         ]
       },
+      "valuation": {
+        "selected-enum": "",
+        "enums": [
+          "SENSITIVE",
+          "SHIELDED",
+          "INTERNAL",
+          "OPEN"
+        ]
+      },
       "population": {
         "concept-type": "Population",
         "selected-id": "",

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -194,7 +194,7 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
 
         self.assertEqual(expected, output)
 
-    def test_remove_optional_not_assigend(self):
+    def test_remove_optional_not_assigned(self):
         data = {
             "name": "ds name",
             "description": "ds description",
@@ -212,7 +212,7 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
                     "optionalConcept": {
                         "concept-type": "optionalConcept",
                         "selected-id": "",
-                        "optional": "true",
+                        "optional": True,
                         "smart-match-id": "",
                         "candidates": []
                     },
@@ -222,7 +222,7 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
                     },
                     "optionalEnum": {
                         "selected-enum": "please-select",
-                        "optional": "true",
+                        "optional": True,
                         "smart-enum": "",
                     }
                 }

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -155,7 +155,6 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
         output = remove_not_selected(doc_output)
 
         self.assertEqual(expected, output)
-        print(json.dumps(output, indent=2))
 
     def test_check_and_remove_not_assigned_instance_variables(self):
         data = {
@@ -193,6 +192,68 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
         doc_output = map_doc_output(data)
         output = remove_not_selected(doc_output)
 
+        self.assertEqual(expected, output)
+
+    def test_remove_optional_not_assigend(self):
+        data = {
+            "name": "ds name",
+            "description": "ds description",
+            'unitType': {'concept-type': 'UnitType', 'selected-id': 'UnitType_DUMMY', 'candidates': []},
+            "instanceVariables": [
+                {
+                    "name": "iv1",
+                    "description": "iv1descr",
+                    "conceptExample": {
+                        "concept-type": "ConceptExample",
+                        "selected-id": "id",
+                        "smart-match-id": "",
+                        "candidates": []
+                    },
+                    "optionalConcept": {
+                        "concept-type": "optionalConcept",
+                        "selected-id": "",
+                        "optional": "true",
+                        "smart-match-id": "",
+                        "candidates": []
+                    },
+                    "enumExample": {
+                        "selected-enum": "VAL1",
+                        "smart-enum": "",
+                    },
+                    "optionalEnum": {
+                        "selected-enum": "please-select",
+                        "optional": "true",
+                        "smart-enum": "",
+                    }
+                }
+            ]
+        }
+
+        expected = {
+            "name": "ds name",
+            "description": "ds description",
+            "unitType": {
+                "concept-type": "UnitType",
+                "selected-id": "UnitType_DUMMY"
+            },
+            "instanceVariables": [
+                {
+                    "name": "iv1",
+                    "description": "iv1descr",
+                    "conceptExample": {
+                        "concept-type": "ConceptExample",
+                        "selected-id": "id"
+                    },
+                    "enumExample": {
+                        "selected-enum": "VAL1"
+                    }
+                }
+            ]
+        }
+
+        doc_output = map_doc_output(data)
+        output = remove_not_selected(doc_output)
+        # print(json.dumps(output, indent=2))
         self.assertEqual(expected, output)
 
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -106,16 +106,94 @@ class DaplaDocumentationMagicsTest(unittest.TestCase):
         output = map_doc_output(doc_template)
         self.assertEqual(expected_doc, output)
 
-
     def test_check_and_remove_output(self):
-        with open(resolve_filename('doc_with_smart_template.json'), 'r') as f:
-            doc_template = json.load(f)
+        data = {
+            "name": "ds name",
+            "description": "ds description",
+            'unitType': {'concept-type': 'UnitType', 'selected-id': 'UnitType_DUMMY', 'candidates': []},
+            "instanceVariables": [
+                {
+                    "name": "iv1",
+                    "description": "iv1descr",
+                    "conceptExample": {
+                        "concept-type": "ConceptExample",
+                        "selected-id": "1",
+                        "smart-match-id": "",
+                        "candidates": []
+                    },
+                    "enumExample": {
+                        "selected-enum": "VAL1",
+                        "smart-enum": "",
+                    }
+                }
+            ]
+        }
 
-        doc_output = map_doc_output(doc_template)
-        # print(json.dumps(doc_output, indent=2))
+        expected = {
+            "name": "ds name",
+            "description": "ds description",
+            "unitType": {
+                "concept-type": "UnitType",
+                "selected-id": "UnitType_DUMMY"
+            },
+            "instanceVariables": [
+                {
+                    "name": "iv1",
+                    "description": "iv1descr",
+                    "conceptExample": {
+                        "concept-type": "ConceptExample",
+                        "selected-id": "1"
+                    },
+                    "enumExample": {
+                        "selected-enum": "VAL1"
+                    }
+                }
+            ]
+        }
 
+        doc_output = map_doc_output(data)
         output = remove_not_selected(doc_output)
+
+        self.assertEqual(expected, output)
         print(json.dumps(output, indent=2))
+
+    def test_check_and_remove_not_assigned_instance_variables(self):
+        data = {
+            "name": "ds name",
+            "description": "ds description",
+            'unitType': {'concept-type': 'UnitType', 'selected-id': 'UnitType_DUMMY', 'candidates': []},
+            "instanceVariables": [
+                {
+                    "name": "iv1",
+                    "description": "iv1descr",
+                    "conceptExample": {
+                        "concept-type": "ConceptExample",
+                        "selected-id": "please-select",
+                        "smart-match-id": "",
+                        "candidates": []
+                    },
+                    "enumExample": {
+                        "selected-enum": "VAL1",
+                        "smart-enum": "",
+                    }
+                }
+            ]
+        }
+
+        expected = {
+            "name": "ds name",
+            "description": "ds description",
+            "unitType": {
+                "concept-type": "UnitType",
+                "selected-id": "UnitType_DUMMY"
+            },
+            "instanceVariables": []
+        }
+
+        doc_output = map_doc_output(data)
+        output = remove_not_selected(doc_output)
+
+        self.assertEqual(expected, output)
 
 
     def test_check_selected_id(self):


### PR DESCRIPTION
We can now add optional types or enum by adding them to dataset-doc-service and setting optional=true
If not selected they will be filtered away when saving