### PR TITLE
DEPENDENCIES equals requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,15 @@ def read(filename):
 
 
 DEPENDENCIES = [
+    'ipython>=4.0.2',
+    'pyspark',
     'jupyterhub',
+    'oauthenticator',
+    'jwt',
     'requests',
-    'requests-cache',
+    'requests-cache==0.5.2',
     'responses',
+    'ipykernel>=4.2.2',
     'notebook>=4.2',
     'tornado>=4',
     'gcsfs==0.6.2',


### PR DESCRIPTION
Apparently, all dependencies are not installed properly when `pip install ssb-ipython-kernel` is called. For example, `jwt `was missing when I tried to install. That might be because it was missing from the DEPENDENCIES list in the `setup.py` file. So now all the packages from `requirements.txt` are added there too.